### PR TITLE
Potential fix for code scanning alert no. 26: Incorrect conversion between integer types

### DIFF
--- a/common/main.go
+++ b/common/main.go
@@ -89,12 +89,12 @@ func ConvertBytes(bytes uint64) string {
 	}
 
 	// For smaller units, use integer format
-	if floatBytes > float64(math.MaxInt) {
-		return fmt.Sprintf("%d %s", math.MaxInt, sizes[i])
-	} else if floatBytes < float64(math.MinInt) {
-		return fmt.Sprintf("%d %s", math.MinInt, sizes[i])
+	if floatBytes > float64(math.MaxInt64) {
+		return fmt.Sprintf("%d %s", int64(math.MaxInt64), sizes[i])
+	} else if floatBytes < 0 {
+		return fmt.Sprintf("%d %s", int64(0), sizes[i])
 	}
-	return fmt.Sprintf("%d %s", int(floatBytes), sizes[i])
+	return fmt.Sprintf("%d %s", int64(floatBytes), sizes[i])
 }
 
 func RemoveLockfile() {


### PR DESCRIPTION
Potential fix for [https://github.com/monobilisim/monokit/security/code-scanning/26](https://github.com/monobilisim/monokit/security/code-scanning/26)

To fix the problem, we should avoid converting a potentially large `uint64` value (or its `float64` representation) to an `int` without ensuring it is within the valid range for `int`. The best way is to:
- Check that `floatBytes` is within the range `[math.MinInt, math.MaxInt]` before converting to `int`.
- If it is out of range, clamp the value to `math.MaxInt` or `math.MinInt` as appropriate.
- Alternatively, since the input is always non-negative (bytes), and `int` is platform-dependent, we can use `uint64` for the integer formatting, or explicitly use `int64` and check bounds.
- For display purposes, it's safest to use `uint64` for the integer part, and only convert to `int` if we are sure the value is within range.

**Implementation plan:**  
- In `ConvertBytes`, for the integer formatting branch, check if `floatBytes` is within `[0, float64(math.MaxInt64)]` (since bytes can't be negative).
- If so, convert to `int64` (or `int` if you are sure `int` is 64 bits), otherwise clamp to `math.MaxInt64`.
- Update the formatting to use `int64` or `uint64` as appropriate.
- No new imports are needed, as `math` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
