### PR TITLE
feat: allow iasdb user to run script and default wildcard port to 5432 for pgsqlHealth

### DIFF
--- a/pgsqlHealth/connection.go
+++ b/pgsqlHealth/connection.go
@@ -131,6 +131,10 @@ func Connect() error {
 				user = parts[3]
 				password = parts[4]
 
+				if port == "*" {
+					port = "5432"
+				}
+
 				break
 			}
 		}

--- a/pgsqlHealth/main.go
+++ b/pgsqlHealth/main.go
@@ -93,9 +93,9 @@ func Main(cmd *cobra.Command, args []string) {
 	version := "4.0.0"
 	common.ScriptName = "pgsqlHealth"
 
-	// Check if user is postgres
-	if os.Getenv("USER") != "postgres" {
-		log.Error().Msg("This script must be run as the postgres user")
+	// Check if user is postgres or iasdb
+	if os.Getenv("USER") != "postgres" && os.Getenv("USER") != "iasdb" {
+		log.Error().Msg("This script must be run as the postgres or iasdb user")
 		return
 	}
 


### PR DESCRIPTION
Çalıştırmak için;
    - `ln -s /var/iasdb/.pgpass /var/lib/postgresql/.pgpass`
    - `chown iasdb: -R /tmp/pgsqlHealth/`
    - `chmod o+r /var/lib/postgresql/.pgpass`