### PR TITLE
fix(versionCheck): PBS update news under cron (follow-up to #42)

### DIFF
--- a/common/versionCheck/main.go
+++ b/common/versionCheck/main.go
@@ -79,11 +79,44 @@ func CreateNews(service string, oldVersion string, newVersion string, compactTit
 	news.Create(identifier+" sunucusunun "+service+" sürümü güncellendi", common.Config.Identifier+" sunucusunda "+service+", "+oldVersion+" sürümünden "+newVersion+" sürümüne yükseltildi.", true)
 }
 
+func ensureSbinInPath() {
+	current := os.Getenv("PATH")
+	existing := make(map[string]bool)
+	for _, p := range strings.Split(current, ":") {
+		if p != "" {
+			existing[p] = true
+		}
+	}
+
+	parts := []string{}
+	if current != "" {
+		parts = append(parts, current)
+	}
+	for _, dir := range []string{"/usr/local/sbin", "/usr/sbin", "/sbin"} {
+		if !existing[dir] {
+			parts = append(parts, dir)
+			existing[dir] = true
+		}
+	}
+
+	if joined := strings.Join(parts, ":"); joined != current {
+		_ = os.Setenv("PATH", joined)
+	}
+}
+
 func VersionCheck(cmd *cobra.Command, args []string) {
 	version := "0.1.0"
 	common.ScriptName = "versionCheck"
 	common.TmpDir = "/var/cache/mono/" + common.ScriptName
 	common.Init()
+
+	// Ensure system binary dirs are on PATH. When monokit runs from cron or a
+	// minimal systemd unit the PATH is often just "/usr/bin:/bin", which omits
+	// /usr/sbin and /sbin. Tools like proxmox-backup-manager, pveversion and
+	// pmgversion live in /usr/sbin, so exec.LookPath would fail and the check
+	// would be silently skipped (no update news). Augment PATH so detection
+	// behaves the same under cron as it does in an interactive shell.
+	ensureSbinInPath()
 
 	fmt.Println("versionCheck - v" + version + " - " + time.Now().Format("2006-01-02 15:04:05"))
 

--- a/common/versionCheck/proxmox.go
+++ b/common/versionCheck/proxmox.go
@@ -88,25 +88,7 @@ func ProxmoxBSCheck() {
 	// Parse the version
 	// Eg. output
 	// proxmox-backup-server 3.3.2-1 running version: 3.3.2
-	// Prefer the clean upstream version after "running version:" so it matches
-	// the PVE/PMG format (no package revision suffix like "-1") and the
-	// endoflife.date cycle lookup.
-	outStr := string(out)
-	var version string
-	if idx := strings.Index(outStr, "running version:"); idx != -1 {
-		rest := strings.TrimSpace(outStr[idx+len("running version:"):])
-		version = strings.Fields(rest)[0]
-	} else {
-		fields := strings.Fields(outStr)
-		if len(fields) > 1 {
-			version = fields[1]
-		}
-	}
-
-	if version == "" {
-		addToVersionErrors(fmt.Errorf("Error parsing Proxmox Backup Server version from output: %q", outStr))
-		return
-	}
+	version := strings.Split(string(out), " ")[1]
 
 	oldVersion := GatherVersion("pbs")
 


### PR DESCRIPTION
## Bağlam

#42 erken merge edildi; asıl fix commit'i (`e353f13` cron PATH) push edilmeden merge olduğu için master'a eksik/yanlış kod gitti:
- ❌ Cron PATH fix'i master'da **yok** (asıl çözüm)
- ❌ Yanlış teşhisle eklenen PBS parse değişikliği master'da **kaldı**
- ✅ eol.go fix master'da doğru

Bu PR onu düzeltir.

## Asıl sorun

PBS sürümü güncellendiğinde otomatik haber (Redmine news) **cron ile çalışınca gitmiyordu**, sadece elle `monokit daemon --once` çalıştırınca gidiyordu.

**Neden:** Cron (ve minimal systemd unit'ler) tipik olarak `PATH=/usr/bin:/bin` ile çalışır — `/usr/sbin` dahil değildir. `proxmox-backup-manager` `/usr/sbin`'de olduğu için `exec.LookPath` cron'da fail ediyor → `ProxmoxBSCheck` sessizce atlanıyor → haber yok. İnteraktif shell'de PATH `/usr/sbin` içerdiği için elle çalışıyordu. `pveversion`/`pmgversion` de çoğunlukla `/usr/sbin`'de olduğundan "hepsinde değil" davranışı oluşuyordu.

## Değişiklikler

1. **`main.go`** — `ensureSbinInPath()` eklendi: `VersionCheck` başında PATH'e `/usr/local/sbin:/usr/sbin:/sbin` ekleniyor (idempotent). Cron'da da interaktif shell'deki gibi tespit çalışıyor.

2. **`proxmox.go`** — #42'de yanlış teşhisle eklenen PBS parse değişikliği geri alındı (karşılaştırma mantığı zaten sorunsuzdu).

## Doğrulama

- `go build ./common/versionCheck/` geçiyor
- PATH genişletme idempotent, mevcut PATH korunuyor