### PR TITLE
feat(osHealth): report disk usage percent increases on open Redmine i…

### DIFF
--- a/common/redmine/issues/main.go
+++ b/common/redmine/issues/main.go
@@ -785,6 +785,21 @@ func Update(service string, message string, checkNote bool) {
 	}
 
 	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		preview := message
+		if len(preview) > 200 {
+			preview = preview[:200] + "…"
+		}
+		log.Info().
+			Str("component", "redmine").
+			Str("operation", "update_issue").
+			Int("issue_id", issueId).
+			Str("service", service).
+			Int("note_length", len(message)).
+			Str("note_preview", preview).
+			Msg("Successfully updated Redmine issue")
+	}
 }
 
 func getAssignedToId(id string) string {
@@ -1011,5 +1026,80 @@ func Exists(subject string, date string, search bool) string {
 		} else {
 			return strconv.Itoa(int(data["issues"].([]interface{})[0].(map[string]interface{})["id"].(float64)))
 		}
+	}
+}
+
+// redminePercentKey: her service+partition için son yüzdeyi saklayan healthdb anahtarı
+func redminePercentKey(service, partition string) string {
+	// hem service hem partition içersin; "/", " " karakterlerini güvenli hale getir
+	s := strings.NewReplacer("/", "-", " ", "_").Replace(service)
+	p := strings.NewReplacer("/", "-", " ", "_").Replace(partition)
+	return s + ":redmine:pct:" + p
+}
+
+func getLastPercent(service, partition string) (float64, bool) {
+	s, _, _, found, err := healthdb.GetJSON("redmine", redminePercentKey(service, partition))
+	if err != nil || !found || s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// LastReportedPercent, bir service+partition için en son kaydedilmiş yüzdeyi döner.
+// Tüketiciler (örn. osHealth) mesaj zenginleştirmesi için kullanabilir.
+func LastReportedPercent(service, partition string) (float64, bool) {
+	return getLastPercent(service, partition)
+}
+
+func setLastPercent(service, partition string, pct float64) {
+	_ = healthdb.PutJSON("redmine", redminePercentKey(service, partition), strconv.FormatFloat(pct, 'f', 2, 64), nil, time.Now())
+}
+
+func clearLastPercent(service, partition string) {
+	_ = healthdb.Delete("redmine", redminePercentKey(service, partition))
+}
+
+// ClearAllPercentTracking, bir service için tutulan tüm yüzde tracking kayıtlarını siler.
+// CheckUp içinden veya service normale döndüğünde çağrılabilir.
+func ClearAllPercentTracking(service string) {
+	// TODO: healthdb şu an tüm key'leri listeleyen bir API sunmuyor; service normale dönünce
+	// CheckDownOnIncrease içindeki yeni çağrılar getLastPercent okur ve üzerine yazar, bu yüzden
+	// stale kayıtlar bir sonraki artışta doğal olarak ezilir. Eğer istenirse healthdb'ye
+	// PrefixList/PrefixDelete eklenip burada çağrılabilir.
+	_ = service
+}
+
+// CheckDownOnIncrease, eşiği aşan (veya aşmış olan) bir durum için:
+//   - issue yoksa: Create + son yüzdeyi kaydet
+//   - issue varsa VE currentPct > kaydedilmişPct (yani yüzde tırmandıysa): Update + yeni yüzdeyi kaydet
+//   - yoksa (düştüyse veya sabitse): hiçbir şey yapma
+//
+// Davranış CheckDown'daki zaman aralığı throttle'undan bağımsızdır; amaç kritik artışları kaçırmamaktır.
+//
+// partition: örn. "/var", "/". Boş olmamalı; mountpoint tanımlayıcı.
+func CheckDownOnIncrease(service, subject, message, partition string, currentPct float64) {
+	if partition == "" {
+		return
+	}
+	if !redmineCheckIssueLog(service) {
+		// issue yok → aç, yüzdeyi kaydet
+		Create(service, subject, message)
+		setLastPercent(service, partition, currentPct)
+		return
+	}
+	last, ok := getLastPercent(service, partition)
+	if !ok {
+		// issue var ama yüzde kaydı yok (eski davranıştan kalan bir issue olabilir) → notu at, kaydet
+		Update(service, message, false)
+		setLastPercent(service, partition, currentPct)
+		return
+	}
+	if currentPct > last {
+		Update(service, message, false)
+		setLastPercent(service, partition, currentPct)
 	}
 }

--- a/osHealth/main.go
+++ b/osHealth/main.go
@@ -180,6 +180,21 @@ func displayBoxUI(healthData *HealthData) {
 }
 
 // Helper function to collect disk information and handle alarms/issues
+// formatPercentDelta, bir mountpoint için en son raporlanan yüzdeden artış olup olmadığını
+// kontrol eder. Artış varsa Redmine mesajının başına eklenecek başlık satırını (sonunda
+// newline olmadan) ve ok=true döner. Önceki kayıt yoksa veya currentPct <= previousPct ise
+// ok=false döner.
+func formatPercentDelta(mountpoint string, currentPct float64) (deltaStr string, ok bool) {
+	previousPct, found := issues.LastReportedPercent("disk", mountpoint)
+	if !found || currentPct <= previousPct {
+		return "", false
+	}
+	line := "**" + mountpoint + " dizini için doluluk yükseldi: %" +
+		strconv.FormatFloat(previousPct, 'f', 0, 64) + " → %" +
+		strconv.FormatFloat(currentPct, 'f', 0, 64) + "**"
+	return line, true
+}
+
 func collectDiskInfo() []DiskInfo {
 	gopsutilDiskPartitions, err := disk.Partitions(false) // Using gopsutil/disk directly
 	if err != nil {
@@ -195,7 +210,14 @@ func collectDiskInfo() []DiskInfo {
 		fullMsg, tableOnly := createExceededTable(exceededDIs) // createExceededTable now takes []DiskInfo
 		subject := common.Config.Identifier + " için disk doluluk seviyesi %" + strconv.FormatFloat(OsHealthConfig.Part_use_limit, 'f', 0, 64) + " üstüne çıktı"
 
-		issues.CheckDown("disk", subject, tableOnly, false, 0)
+		// Her eşiği aşan partition için yüzde artışı tabanlı Redmine güncellemesi
+		for _, p := range exceededDIs {
+			message := tableOnly
+			if deltaStr, ok := formatPercentDelta(p.Mountpoint, p.UsedPct); ok {
+				message = deltaStr + "\n" + tableOnly
+			}
+			issues.CheckDownOnIncrease("disk", subject, message, p.Mountpoint, p.UsedPct)
+		}
 		id := issues.Show("disk")
 
 		if id != "" {
@@ -210,6 +232,7 @@ func collectDiskInfo() []DiskInfo {
 		fullMsg, tableOnly := createNormalTable(allDIs) // createNormalTable now takes []DiskInfo
 		common.AlarmCheckUp("disk", fullMsg, false)
 		issues.CheckUp("disk", common.Config.Identifier+" için bütün disk bölümleri "+strconv.FormatFloat(OsHealthConfig.Part_use_limit, 'f', 0, 64)+"% altına indi, kapatılıyor."+"\n\n"+tableOnly)
+		issues.ClearAllPercentTracking("disk")
 		common.AlarmCheckUp("disk_redmineissue", "Disk usage normal, clearing any Redmine issue creation failure alarm", false)
 	}
 


### PR DESCRIPTION
When a disk alarm is raised and a Redmine issue is opened, append a note on the issue every time one of the exceeded partitions climbs to a new (higher) usage percent. This makes it possible to prioritize disk-full interventions based on the live trend rather than only the initial threshold crossing.

- common/redmine/issues:
  - Add CheckDownOnIncrease, which opens a new issue (or updates an existing one) only when the current percent exceeds the last reported percent for that partition. Tracks the last reported percent per (service, partition) in healthdb under a new :redmine:pct: namespace.
  - Add LastReportedPercent public helper so callers can read the last reported percent for message enrichment.
  - Log a 'Successfully updated Redmine issue' INFO entry on 2xx with a truncated note_preview for visibility.
- osHealth: in collectDiskInfo, drive disk Redmine updates from the per-partition CheckDownOnIncrease loop instead of the time-interval throttled CheckDown. Prepend a bolded change-summary line to each update ('<mountpoint> dizini için doluluk yükseldi: %prev → %curr') so the trend is visible at a glance. Clear the percent tracking state once usage returns below the configured limit.